### PR TITLE
Add admin menu for Map and Workshop

### DIFF
--- a/django_project/proposals/admin.py
+++ b/django_project/proposals/admin.py
@@ -1,6 +1,10 @@
 from django.contrib import admin
 
 from .models import TalkProposal
+from .models import MapProposal
+from .models import WorkshopProposal
 
 
 admin.site.register(TalkProposal)
+admin.site.register(MapProposal)
+admin.site.register(WorkshopProposal)


### PR DESCRIPTION
This fixes #77, fixes #74 

As for review, if logged in user is also the one who speak on the proposal, the proposal won't show. You only can review others proposals. Also do not forget to add permission can_review_<proposal_name> or can_manage_<proposal_name> for logged in user from admin panel.

![image](https://cloud.githubusercontent.com/assets/2271663/23885425/6e608e48-08a5-11e7-9ae0-764fe38d4aaf.png)
