### PR TITLE
Complete Profile Email Notification

### DIFF
--- a/django_project/core/adapter.py
+++ b/django_project/core/adapter.py
@@ -1,5 +1,7 @@
 from account.hooks import AccountDefaultHookSet
-from django.conf import settings
+from django.core.mail import send_mail
+from django.template.loader import render_to_string
+from account.conf import settings
 
 
 class PinaxAccountHookset(AccountDefaultHookSet):
@@ -15,3 +17,9 @@ class PinaxAccountHookset(AccountDefaultHookSet):
             "host": settings.CONFERENCE_DOMAIN
         }
         super(PinaxAccountHookset,self).send_password_reset_email(to, newcontext)
+
+    def send_complete_profile_email(self,to,ctx):
+        subject = render_to_string("account/email/email_complete_profile_subject.txt",ctx)
+        subject = "".join(subject.splitlines())  # remove superfluous line breaks
+        message = render_to_string("account/email/email_complete_profile_message.txt", ctx)
+        send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, to)

--- a/django_project/core/templates/account/email/email_complete_profile_message.txt
+++ b/django_project/core/templates/account/email/email_complete_profile_message.txt
@@ -1,6 +1,6 @@
 Dear {{ username }}
 
-Thank you for registering on FOSS4G 2017
+Thank you for registering for FOSS4G 2017
 
 Please complete your profile here:
 {{host}}/en/speaker/edit/

--- a/django_project/core/templates/account/email/email_complete_profile_message.txt
+++ b/django_project/core/templates/account/email/email_complete_profile_message.txt
@@ -1,0 +1,10 @@
+Dear {{ username }}
+
+Thank you for registering on FOSS4G 2017
+
+Please complete your profile here:
+{{host}}/en/speaker/edit/
+
+And you can change your profile settings here
+
+{{host}}/en/account/settings

--- a/django_project/core/templates/account/email/email_complete_profile_subject.txt
+++ b/django_project/core/templates/account/email/email_complete_profile_subject.txt
@@ -1,0 +1,1 @@
+Complete Your Profile on FOSS4G 2017

--- a/django_project/pinaxcon_theme/__init__.py
+++ b/django_project/pinaxcon_theme/__init__.py
@@ -3,5 +3,6 @@ Provides a agenda app with events, keywords, locations and comments.
 Events can be listed by month, keyword, location or author.
 """
 from __future__ import unicode_literals
+import signal_receiver
 
 __version__ = "0.0.1"

--- a/django_project/pinaxcon_theme/hooks.py
+++ b/django_project/pinaxcon_theme/hooks.py
@@ -10,9 +10,3 @@ class Foss4GAccountHookset(AccountDefaultHookSet):
         subject = "".join(subject.splitlines())  # remove superfluous line breaks
         message = render_to_string("account/email/email_confirmation_message.txt", ctx)
         send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, to)
-
-    def send_complete_profile_email(self,to,ctx):
-        subject = render_to_string("account/email/email_complete_profile_subject.txt",ctx)
-        subject = "".join(subject.splitlines())  # remove superfluous line breaks
-        message = render_to_string("account/email/email_complete_profile_message.txt", ctx)
-        send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, to)

--- a/django_project/pinaxcon_theme/hooks.py
+++ b/django_project/pinaxcon_theme/hooks.py
@@ -10,3 +10,9 @@ class Foss4GAccountHookset(AccountDefaultHookSet):
         subject = "".join(subject.splitlines())  # remove superfluous line breaks
         message = render_to_string("account/email/email_confirmation_message.txt", ctx)
         send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, to)
+
+    def send_complete_profile_email(self,to,ctx):
+        subject = render_to_string("account/email/email_complete_profile_subject.txt",ctx)
+        subject = "".join(subject.splitlines())  # remove superfluous line breaks
+        message = render_to_string("account/email/email_complete_profile_message.txt", ctx)
+        send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, to)

--- a/django_project/pinaxcon_theme/signal_receiver.py
+++ b/django_project/pinaxcon_theme/signal_receiver.py
@@ -1,0 +1,18 @@
+from account.signals import email_confirmed
+from django.dispatch import receiver
+import logging
+from account.hooks import hookset
+import re
+
+
+@receiver(email_confirmed)
+def email_confirmed_callback(sender, **kwargs):
+    accounts_data = kwargs.get("email_address","failed").split()
+    if len(accounts_data) > 1:
+        email_address = accounts_data[0]
+        username = re.sub('()','',accounts_data[1])
+        ctx = {
+            "email_address": email_address,
+            "username":username
+        }
+        hookset.send_complete_profile_email(email_address,ctx)

--- a/django_project/pinaxcon_theme/signal_receiver.py
+++ b/django_project/pinaxcon_theme/signal_receiver.py
@@ -1,18 +1,20 @@
 from account.signals import email_confirmed
 from django.dispatch import receiver
-import logging
+from account.conf import settings
 from account.hooks import hookset
+from account.models import EmailAddress
 import re
 
 
 @receiver(email_confirmed)
 def email_confirmed_callback(sender, **kwargs):
-    accounts_data = kwargs.get("email_address","failed").split()
-    if len(accounts_data) > 1:
-        email_address = accounts_data[0]
-        username = re.sub('()','',accounts_data[1])
-        ctx = {
-            "email_address": email_address,
-            "username":username
-        }
-        hookset.send_complete_profile_email(email_address,ctx)
+    email = kwargs.get("email_address")
+    email_address = email.email
+    username = email.user.username
+    ctx = {
+        "host": settings.CONFERENCE_DOMAIN,
+        "email_address": email_address,
+        "username": username
+    }
+    hookset.send_complete_profile_email([email_address], ctx)
+


### PR DESCRIPTION
This fixes #117 

Email Template:

```
Dear <user>

Thank you for registering on FOSS4G 2017

Please complete your profile here:
https://foss4g-africa.org/en/speaker/edit/

And you can change your profile settings here

https://foss4g-africa.org/en/account/settings
```