### PR TITLE
show sponsor logo on sidebar

### DIFF
--- a/django_project/core/templates/_default_sidebar.html
+++ b/django_project/core/templates/_default_sidebar.html
@@ -21,7 +21,7 @@
             {% for sponsor in level.sponsors %}
                 <div style="margin: 10px 0;">
                     <a href="{{ sponsor.external_url }}">
-{#                        <img src="{% thumbnail sponsor.website_logo '100x60' %}" alt="{{ sponsor.name }}" />#}
+                        <img src="{{ MEDIA_URL }}{{ sponsor.sponsor_logo.upload }}" width="60" height="60" alt="{{ sponsor.name }}" />
                     </a>
                 </div>
             {% endfor %}


### PR DESCRIPTION
fix #146 

shows sponsor logo on the side bar and when it is clicked, user goes to sponsor link.

![screenshot from 2017-05-02 17-48-56](https://cloud.githubusercontent.com/assets/26101337/25615113/a7eb49ec-2f5f-11e7-9efd-1d9b1068b91b.png)
